### PR TITLE
Check that serviceConfig exists

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ services:
   - docker
 
 env:
-  DOCKER_VERSION: 1.12.0-0~trusty
+  DOCKER_VERSION: 1.13.1-0~ubuntu-trusty
   DOCKER_COMPOSE_VERSION: 1.8.0
   DEBUG: "navy:*"
   NAVY_DEBUG: "navy:*"

--- a/packages/navy/src/middleware/tag-override.js
+++ b/packages/navy/src/middleware/tag-override.js
@@ -7,7 +7,7 @@ export default (config: Object, state: Object) => {
     const serviceConfig = newConfig.services[serviceName]
     const serviceState = state.services[serviceName]
 
-    if (serviceState._tag) {
+    if (serviceState._tag && serviceConfig) {
       let image = serviceConfig.image
 
       // strip existing tag off if it exists


### PR DESCRIPTION
Fix a small bug where misspelling the the name of the service that you want to use for a given tag e.g. `navy use-tag live-dev missspelt` results in navy unable to launch and services