### PR TITLE
Don't test against unsupported Node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,7 @@ language: node_js
 node_js:
   - "7"
   - "6"
-  - "5"
   - "4"
-  - "0.12"
 
 services:
   - docker


### PR DESCRIPTION
Node 0.12 and 5 both reached end of life last year, so I don't think it's worth testing against them anymore.

cc @madjam002 @jeanpaulgorman 

https://github.com/nodejs/LTS