### PR TITLE
Handle errors when traversing the node_modules dir

### DIFF
--- a/packages/navy-plugin-nodejs/src/hooks/rewrite-linked-node-modules.js
+++ b/packages/navy-plugin-nodejs/src/hooks/rewrite-linked-node-modules.js
@@ -1,9 +1,16 @@
 import findit from 'findit'
 import path from 'path'
 import fs from 'fs'
+import os from 'os'
+
+import {name as pluginName} from '../../package.json'
 
 export default () => {
   const finder = findit(path.join(process.cwd(), 'node_modules'))
+
+  finder.on('error', err => {
+    console.error(`${pluginName} failed to traverse your node_modules directory:`, os.EOL, err.toString())
+  })
 
   finder.on('link', link => {
     if (link.indexOf('.bin') !== -1) return


### PR DESCRIPTION
The navy-plugin-nodejs `beforeLaunch` hook doesn't add a listener for errors when traversing the file system. This has had the indirect effect of making the plugin assume that every `navy develop` command is being performed on a Node.js project.

Instead i've caught the event and just emitted a message in the error console. The develop command can continue and any errors from a missing `node_modules` directory will just surface from node directly.

Thoughts?

cc @madjam002 @jeanpaulgorman @ozamarripa 