### PR TITLE
Use the fs utility throughtout navy

### DIFF
--- a/packages/navy/src/cli/import.js
+++ b/packages/navy/src/cli/import.js
@@ -2,6 +2,7 @@
 
 import path from 'path'
 import chalk from 'chalk'
+
 import fs from '../util/fs'
 import {getNavy} from '../'
 import {getImportOptionsForCLI} from '../config-provider'

--- a/packages/navy/src/cli/import.js
+++ b/packages/navy/src/cli/import.js
@@ -1,8 +1,8 @@
 /* @flow */
 
-import fs from 'fs'
 import path from 'path'
 import chalk from 'chalk'
+import fs from '../util/fs'
 import {getNavy} from '../'
 import {getImportOptionsForCLI} from '../config-provider'
 import {importNavy} from './util'

--- a/packages/navy/src/config.js
+++ b/packages/navy/src/config.js
@@ -3,6 +3,7 @@
 import path from 'path'
 import bluebird from 'bluebird'
 import invariant from 'invariant'
+
 import fs from './util/fs'
 
 const DEFAULT_ENVIRONMENT_NAME = 'dev'

--- a/packages/navy/src/config.js
+++ b/packages/navy/src/config.js
@@ -3,6 +3,7 @@
 import path from 'path'
 import bluebird from 'bluebird'
 import invariant from 'invariant'
+import fs from './util/fs'
 
 const DEFAULT_ENVIRONMENT_NAME = 'dev'
 
@@ -11,7 +12,6 @@ const DEFAULT_CONFIG = {
   externalIP: null,
 }
 
-const fs = bluebird.promisifyAll(require('fs'))
 const mkdirp = bluebird.promisify(require('mkdirp'))
 
 export type Config = {

--- a/packages/navy/src/drivers/docker-compose/client.js
+++ b/packages/navy/src/drivers/docker-compose/client.js
@@ -1,17 +1,15 @@
 /* @flow */
 
 import path from 'path'
-import bluebird from 'bluebird'
 import invariant from 'invariant'
 
+import fs from '../../util/fs'
 import {Navy} from '../../navy'
 import {execAsync} from '../../util/exec-async'
 import {log} from '../../driver-logging'
 import {pathToNavy} from '../../navy/state'
 
 import type {ConfigProvider} from '../../config-provider'
-
-const fs = bluebird.promisifyAll(require('fs'))
 
 export type ComposeClient = {
   exec(command: string, args: any, opts?: Object): Promise<string>,

--- a/packages/navy/src/drivers/docker-compose/index.js
+++ b/packages/navy/src/drivers/docker-compose/index.js
@@ -1,8 +1,8 @@
 /* @flow */
 
 import yaml from 'js-yaml'
-import bluebird from 'bluebird'
 
+import fs from '../../util/fs'
 import docker from '../../util/docker-client'
 import {createComposeClient} from './client'
 import {Navy} from '../../navy'
@@ -11,8 +11,6 @@ import {getContainerName} from '../../util'
 
 import type {Driver} from '../../driver'
 import type {ServiceList} from '../../service'
-
-const fs = bluebird.promisifyAll(require('fs'))
 
 const debug = require('debug')('navy:docker-compose')
 

--- a/packages/navy/src/navy/index.js
+++ b/packages/navy/src/navy/index.js
@@ -1,9 +1,9 @@
 /* @flow */
 
-import bluebird from 'bluebird'
 import invariant from 'invariant'
 import {EventEmitter2} from 'eventemitter2'
 
+import fs from '../util/fs'
 import {resolveDriverFromName} from '../driver'
 import {resolveConfigProviderFromName} from '../config-provider'
 import {normaliseNavyName} from './util'
@@ -20,8 +20,6 @@ import type {Driver, CreateDriver} from '../driver'
 import type {ConfigProvider, CreateConfigProvider} from '../config-provider'
 import type {State} from './state'
 import type {ServiceList} from '../service'
-
-const fs = bluebird.promisifyAll(require('fs'))
 
 export type {State}
 

--- a/packages/navy/src/navy/state.js
+++ b/packages/navy/src/navy/state.js
@@ -4,9 +4,10 @@ import path from 'path'
 import invariant from 'invariant'
 import bluebird from 'bluebird'
 
+import fs from '../util/fs'
+
 const debug = require('debug')('navy:state')
 
-const fs = bluebird.promisifyAll(require('fs'))
 const mkdirp = bluebird.promisify(require('mkdirp'))
 const rimraf = bluebird.promisify(require('rimraf'))
 


### PR DESCRIPTION
The fs module is imported and then promsified in many points of the
source. Each promisifyAll(fs) call takes ~10-15ms. Reducing that to
a single call will add a slight improvement to startup time of the cli.