### PR TITLE
Improve navy update when no services are running

### DIFF
--- a/packages/navy/src/drivers/docker-compose/index.js
+++ b/packages/navy/src/drivers/docker-compose/index.js
@@ -116,7 +116,17 @@ export default function createDockerComposeDriver(navy: Navy): Driver {
       }
 
       await exec('pull', services)
-      await exec('up', ['-d', '--no-deps', ...services])
+
+      // only relaunch services which are already running
+      const launchedServiceNames = toLookupTable(await this.getLaunchedServiceNames())
+      const servicesToRelaunch = services.filter((name) => launchedServiceNames[name])
+
+      if (servicesToRelaunch.length) {
+        await exec('up', ['-d', '--no-deps', ...services])
+      }
+    },
+
+    async up(services: ?Array<string>): Promise<void> {
     },
 
     async spawnLogStream(services: ?Array<string>): Promise<void> {
@@ -181,4 +191,10 @@ export default function createDockerComposeDriver(navy: Navy): Driver {
   }
 
   return driver
+}
+
+function toLookupTable(keys: Array<string>): Object {
+  const lookupTable = {}
+  keys.forEach((key) => lookupTable[key] = true)
+  return lookupTable
 }

--- a/packages/navy/src/navy/index.js
+++ b/packages/navy/src/navy/index.js
@@ -345,12 +345,13 @@ export class Navy extends EventEmitter2 {
   }
 
   /**
-   * Makes sure the images for the given services are up to date, and restarts any services
-   * with new images.
+   * Makes sure the images for the given services are up to date, and restarts any running
+   * services with new images.
    * @public
    */
   async update(services?: Array<string>): Promise<void> {
-    if (!services) services = await this.getLaunchedServiceNames()
+    // update all images by default
+    if (!services) services = await this.getAvailableServiceNames()
 
     await (await this.safeGetDriver()).update(services)
   }


### PR DESCRIPTION
Currently, if you run 'navy update' when no services are running, it
will update all images, but also launch all services, which is probably
not what you want.

What this now does in that case is to update all images, and launch no
services.

In general, 'navy update' will now:

- navy update:
  - update all images
  - launch all currently running services
- navy update <services>
  - update given images
  - launch given images, only if already running

Note that I haven't tested this locally, I haven't yet figured out how to get a good dev environment that isn't a faff to test.