### PR TITLE
Fix integration testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ services:
 
 env:
   matrix:
-    - DOCKER_VERSION=1.13.1-0~ubuntu-trusty
-    - DOCKER_VERSION=1.12.6-0~ubuntu-trusty
+    - DOCKER_TAG=1.13-dind
+    - DOCKER_TAG=1.12-dind
   global:
     - DEBUG='navy:*' NAVY_DEBUG='navy:*' DOCKER_COMPOSE_VERSION=1.8.0
 
@@ -28,27 +28,14 @@ matrix:
 
   include:
     - node_js: 6
-      env: DOCKER_VERSION=1.11.2-0~trusty
+      env: DOCKER_TAG=1.11-dind
     - node_js: 6
-      env: DOCKER_VERSION=1.10.3-0~trusty
+      env: DOCKER_TAG=1.10-dind
 
 before_install:
-  # list docker-engine versions
-  - apt-cache madison docker-engine
-
-  # upgrade docker-engine to specific version
-  - sudo apt-get purge -y docker-engine
-  - sudo apt-get -o Dpkg::Options::="--force-confnew" install -y docker-engine=${DOCKER_VERSION}
-
-  # reinstall docker-compose at specific version
-  - sudo rm /usr/local/bin/docker-compose
-  - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
-  - chmod +x docker-compose
-  - sudo mv docker-compose /usr/local/bin
-
   # print versions
   - docker --version
-  - docker-compose --version
+  - echo $TRAVIS_NODE_VERSION
 
 before_script:
   # bootstrap packages

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,6 @@ matrix:
 before_install:
   # print versions
   - docker --version
-  - echo $TRAVIS_NODE_VERSION
 
 before_script:
   # bootstrap packages

--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -9,6 +9,7 @@ echo ""
 
 DOCKER_TAG=${DOCKER_TAG:-1.12-dind}
 DOCKER_COMPOSE_VERSION=${DOCKER_COMPOSE_VERSION:-1.8.0}
+NODE_VERSION=${TRAVIS_NODE_VERSION:-6}
 
 docker run -d --name navy-test-runner-daemon --privileged \
   -v $(pwd):/usr/src/app \
@@ -18,6 +19,7 @@ docker build \
     -t navy-test-runner \
     -f test/integration/runner/Dockerfile \
     --build-arg DOCKER_COMPOSE_VERSION=$DOCKER_COMPOSE_VERSION \
+    --build-arg NODE_VERSION=$NODE_VERSION \
     .
 
 echo ""

--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -1,3 +1,5 @@
+set -e
+
 echo ""
 echo "SETTING UP ENVIRONMENT"
 echo "This may take several minutes to build the necessary docker containers..."
@@ -5,11 +7,18 @@ echo "This will only take a while the first time you run the tests, subsequent r
 echo ""
 echo ""
 
+DOCKER_TAG=${DOCKER_TAG:-1.12-dind}
+DOCKER_COMPOSE_VERSION=${DOCKER_COMPOSE_VERSION:-1.8.0}
+
 docker run -d --name navy-test-runner-daemon --privileged \
   -v $(pwd):/usr/src/app \
-  docker:1.12-dind --storage-driver=aufs
+  docker:$DOCKER_TAG --storage-driver=aufs
 
-docker build -t navy-test-runner -f test/integration/runner/Dockerfile .
+docker build \
+    -t navy-test-runner \
+    -f test/integration/runner/Dockerfile \
+    --build-arg DOCKER_COMPOSE_VERSION=$DOCKER_COMPOSE_VERSION \
+    .
 
 echo ""
 echo ""

--- a/test/integration/runner/Dockerfile
+++ b/test/integration/runner/Dockerfile
@@ -1,14 +1,12 @@
 FROM ubuntu
 
-ENV DOCKER_BUCKET get.docker.com
-ENV DOCKER_VERSION 1.12.0
-ENV DOCKER_SHA256 3dd07f65ea4a7b4c8829f311ab0213bca9ac551b5b24706f3e79a97e22097f8b
+ARG DOCKER_COMPOSE_VERSION
 
 RUN apt-get update -y && apt-get install -y build-essential git curl
 
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - && apt-get install -y nodejs python-software-properties python
 
-RUN curl -L https://github.com/docker/compose/releases/download/1.8.0/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
+RUN curl -L https://github.com/docker/compose/releases/download/$DOCKER_COMPOSE_VERSION/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
 RUN chmod +x /usr/local/bin/docker-compose
 
 ADD ./test/integration/runner/docker-entrypoint.sh /usr/local/bin/

--- a/test/integration/runner/Dockerfile
+++ b/test/integration/runner/Dockerfile
@@ -1,10 +1,11 @@
 FROM ubuntu
 
 ARG DOCKER_COMPOSE_VERSION
+ARG NODE_VERSION
 
 RUN apt-get update -y && apt-get install -y build-essential git curl
 
-RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - && apt-get install -y nodejs python-software-properties python
+RUN curl -sL https://deb.nodesource.com/setup_$NODE_VERSION.x | bash - && apt-get install -y nodejs python-software-properties python
 
 RUN curl -L https://github.com/docker/compose/releases/download/$DOCKER_COMPOSE_VERSION/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
 RUN chmod +x /usr/local/bin/docker-compose


### PR DESCRIPTION
The integration tests run in their own container and navy
uses a dedicated docker daemon running in another container
on the host VM. We do not pass the environment variables
from the travis matrix down to the scripts that setup this
testing environment. Hence until now, all test builds have
been using the same version of docker and docker-compose.