### PR TITLE
Fix HTTP proxy not discovering port 80 containers

### DIFF
--- a/packages/navy/src/middleware/add-virtual-hosts.js
+++ b/packages/navy/src/middleware/add-virtual-hosts.js
@@ -15,7 +15,8 @@ const getServiceHTTPProxyConfig = (serviceName, navyFile) => {
 
 const serviceHasPort80 = service =>
   service.ports && find(service.ports, port =>
-    port.toString() === '80'
+    // Should handle "80" (short syntax), "80:80" (long syntax), and "80/tcp" (including protocol) formats.
+    port.toString() === '80' || port.toString().startsWith('80:') || port.toString().startsWith('80/')
   )
 
 export default (navy: Navy) =>


### PR DESCRIPTION
For whatever reason, navy was not auto-discovering that my container published port 80 as it should. It was because `serviceHasPort80` was only checking for port `80` explicitly, but it was returned as `80/tcp` for me. I've extended the check to account for this use case, as well as if someone uses the long format to publish a port in their compose file (`80:80`). Maybe the return value changed in a newer docker version, but it always appears to append the protocol for me.

- `docker version 17.06.0-ce, build 02c1d87`
- `docker-compose version 1.14.0, build c7bdf9e`
- `node v7.10.0`

This was reproducible using the demo compose file, e.g.

```yaml
version: "2"
services:
  web:
    image: navycloud/hello-world
    ports:
      - "80"
```