### PR TITLE
getLaunchedNavies now validates that a navy path is a directory

### DIFF
--- a/packages/navy/src/navy/index.js
+++ b/packages/navy/src/navy/index.js
@@ -7,7 +7,7 @@ import fs from '../util/fs'
 import {resolveDriverFromName} from '../driver'
 import {resolveConfigProviderFromName} from '../config-provider'
 import {normaliseNavyName} from './util'
-import {getState, saveState, deleteState, pathToNavys} from './state'
+import {getState, saveState, deleteState, pathToNavys, pathToNavy} from './state'
 import {getConfig} from '../config'
 import {NavyNotInitialisedError, NavyError} from '../errors'
 import {loadPlugins} from './plugin-interface'
@@ -575,7 +575,9 @@ export function getNavy(navyName: ?string): Navy {
 export async function getLaunchedNavies(): Promise<Array<Navy>> {
   try {
     const navyNames = await fs.readdirAsync(pathToNavys())
-    return navyNames.map(name => getNavy(name))
+    return navyNames
+      .filter(node => fs.lstatSync(pathToNavy(node)).isDirectory())
+      .map(name => getNavy(name))
   } catch (ex) {
     return []
   }


### PR DESCRIPTION
Calls to Navy.safeGetDriver within various methods were throwing
an Error when that navies directory contained a file. One example
being the unintended existence of a .DS_Store file on MacOS.
getLaunchedNavies now filters out all non-directory nodes. Manually
creating an empty directory instead would still surface the problem,
however this would be a seen as an intentional corruption of the navies
directory and the doctor command can be used to resolve this.

Fixes #68