### PR TITLE
More middlewarez

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ npm-debug.log
 lib
 website/build
 */**/package-lock.json
+.vscode

--- a/packages/navy/src/middleware/set-env-vars.js
+++ b/packages/navy/src/middleware/set-env-vars.js
@@ -1,0 +1,18 @@
+/* @flow */
+
+import {mapValues} from 'lodash'
+
+
+export default (config: Object, state: Object) => ({
+  ...config,
+  services: mapValues(config.services, (serviceConfig, serviceName) => {
+    const serviceState = state.services[serviceName] || {}
+    return {
+      ...serviceConfig,
+      environment: {
+        ...serviceConfig.environment,
+        ...serviceState.environment,
+      },
+    }
+  }),
+})

--- a/packages/navy/src/middleware/set-logging-driver.js
+++ b/packages/navy/src/middleware/set-logging-driver.js
@@ -1,0 +1,18 @@
+/* @flow */
+
+import {mapValues} from 'lodash'
+
+
+export default (config: Object, state: Object) => ({
+  ...config,
+  services: mapValues(config.services, (serviceConfig, serviceName) => {
+    const serviceState = state.services[serviceName] || {}
+    return {
+      ...serviceConfig,
+      logging: {
+        ...serviceConfig.logging,
+        ...serviceState.logging,
+      },
+    }
+  }),
+})

--- a/packages/navy/src/navy/default-middleware.js
+++ b/packages/navy/src/navy/default-middleware.js
@@ -2,7 +2,8 @@ import developMiddleware from '../middleware/develop'
 import tagOverrideMiddleware from '../middleware/tag-override'
 import portOverrideMiddleware from '../middleware/port-override'
 import addVirtualHostsMiddleware from '../middleware/add-virtual-hosts'
-import setEnvironmentVariables from "../middleware/set-env-vars"
+import setEnvironmentVariables from '../middleware/set-env-vars'
+import setLoggingDriver from '../middleware/set-logging-driver'
 
 import type {Navy} from './'
 
@@ -11,5 +12,6 @@ export default (navy: Navy) => ([
   tagOverrideMiddleware,
   portOverrideMiddleware,
   setEnvironmentVariables,
+  setLoggingDriver,
   addVirtualHostsMiddleware(navy),
 ])

--- a/packages/navy/src/navy/default-middleware.js
+++ b/packages/navy/src/navy/default-middleware.js
@@ -2,6 +2,7 @@ import developMiddleware from '../middleware/develop'
 import tagOverrideMiddleware from '../middleware/tag-override'
 import portOverrideMiddleware from '../middleware/port-override'
 import addVirtualHostsMiddleware from '../middleware/add-virtual-hosts'
+import setEnvironmentVariables from "../middleware/set-env-vars"
 
 import type {Navy} from './'
 
@@ -9,5 +10,6 @@ export default (navy: Navy) => ([
   developMiddleware,
   tagOverrideMiddleware,
   portOverrideMiddleware,
+  setEnvironmentVariables,
   addVirtualHostsMiddleware(navy),
 ])


### PR DESCRIPTION
This change allows us to initialise a navy from the JS API with some extra stuff that will override docker-compose config for a service.

The two parts we can now overwrite are [logging](https://docs.docker.com/compose/compose-file/#logging) and [environment](https://docs.docker.com/compose/compose-file/#environment).

Example:

```js
await navy.initialise({
  services: {
    myService: {

      // anything in here will be set as an environment variable in myService:
      environment: {
        MY_ENV_VAR: "yay",
      },

      // this will set the Docker logging driver used by myService:
      logging: {
        driver: "json-file",
      },
    },
  },
})
```