### PR TITLE
Allow setting image in middleware

### DIFF
--- a/packages/navy/src/middleware/set-image.js
+++ b/packages/navy/src/middleware/set-image.js
@@ -9,10 +9,7 @@ export default (config: Object, state: Object) => ({
     const serviceState = state.services[serviceName] || {}
     return {
       ...serviceConfig,
-      image: {
-        ...serviceConfig.image,
-        ...serviceState.image,
-      },
+      image: serviceState.image || serviceConfig.image,
     }
   }),
 })

--- a/packages/navy/src/middleware/set-image.js
+++ b/packages/navy/src/middleware/set-image.js
@@ -1,0 +1,18 @@
+/* @flow */
+
+import {mapValues} from 'lodash'
+
+
+export default (config: Object, state: Object) => ({
+  ...config,
+  services: mapValues(config.services, (serviceConfig, serviceName) => {
+    const serviceState = state.services[serviceName] || {}
+    return {
+      ...serviceConfig,
+      image: {
+        ...serviceConfig.image,
+        ...serviceState.image,
+      },
+    }
+  }),
+})

--- a/packages/navy/src/navy/default-middleware.js
+++ b/packages/navy/src/navy/default-middleware.js
@@ -4,6 +4,7 @@ import portOverrideMiddleware from '../middleware/port-override'
 import addVirtualHostsMiddleware from '../middleware/add-virtual-hosts'
 import setEnvironmentVariables from '../middleware/set-env-vars'
 import setLoggingDriver from '../middleware/set-logging-driver'
+import setImage from '../middleware/set-image'
 
 import type {Navy} from './'
 
@@ -13,5 +14,6 @@ export default (navy: Navy) => ([
   portOverrideMiddleware,
   setEnvironmentVariables,
   setLoggingDriver,
+  setImage,
   addVirtualHostsMiddleware(navy),
 ])


### PR DESCRIPTION
This allows us to set which image we want to use from the JS API.

Example use case: API testing where we want to:

- build a production image
- use this image inside navy to run tests against