### PR TITLE
Increase maxBuffer when checking for valid docker compose config

### DIFF
--- a/packages/navy/src/config-providers/filesystem/index.js
+++ b/packages/navy/src/config-providers/filesystem/index.js
@@ -11,7 +11,7 @@ import type {Navy} from '../../navy'
 
 async function cwdHasValidDockerComposeConfig() {
   try {
-    await execAsync('docker-compose', ['config'], null, { cwd: process.cwd() })
+    await execAsync('docker-compose', ['config'], null, { maxBuffer: Infinity, cwd: process.cwd() })
   } catch (ex) {
     return false
   }


### PR DESCRIPTION
We ran with an issue where our environment generates a docker-compose.yml
with a size of ~300kb. The default value of maxBuffer when executing a
command is of 200kb and if the size is larger than that it causes an
exception which prevents creating the environment overall.

I increased it to 500kb for now but I'm not sure if there is a better way to 
check if the config is valid without just increasing this value.