### PR TITLE
Allow overriding retry behaviour in waitForHealthy

### DIFF
--- a/packages/navy/package-lock.json
+++ b/packages/navy/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "navy",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -225,6 +225,11 @@
       "requires": {
         "once": "^1.4.0"
       }
+    },
+    "err-code": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
+      "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -539,6 +544,15 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
     },
+    "promise-retry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
+      "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
+      "requires": {
+        "err-code": "^1.0.0",
+        "retry": "^0.10.0"
+      }
+    },
     "pump": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.2.tgz",
@@ -582,6 +596,11 @@
         "onetime": "^2.0.0",
         "signal-exit": "^3.0.2"
       }
+    },
+    "retry": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
+      "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q="
     },
     "rimraf": {
       "version": "2.6.2",

--- a/packages/navy/package.json
+++ b/packages/navy/package.json
@@ -40,6 +40,7 @@
     "mkdirp": "^0.5.1",
     "opn": "^5.3.0",
     "pad": "^1.0.0",
+    "promise-retry": "^1.1.1",
     "resolve": "^1.1.7",
     "rimraf": "^2.5.2",
     "simple-docker-registry-client": "^1.1.0",

--- a/packages/navy/src/index.d.ts
+++ b/packages/navy/src/index.d.ts
@@ -37,12 +37,18 @@ declare module "navy" {
       services?: Array<string> | null,
       opts?: LaunchOptions,
     ) => Promise<void>
+    start: (services?: Array<string>) => Promise<void>
+    stop: (services?: Array<string>) => Promise<void>
+    restart: (services?: Array<string>) => Promise<void>
+    kill: (services?: Array<string>) => Promise<void>
+    rm: (services?: Array<string>) => Promise<void>
+    update: (services?: Array<string>) => Promise<void>
     port: (
       service: string,
       privatePort: number,
       index?: number,
     ) => Promise<number | undefined>
-    spawnLogStream: (services: Array<string>) => Promise<void>
+    spawnLogStream: (services?: Array<string>) => Promise<void>
     url: (service: string) => Promise<string>
     waitForHealthy: (
       services?: Array<string> | null,

--- a/packages/navy/src/index.d.ts
+++ b/packages/navy/src/index.d.ts
@@ -47,6 +47,11 @@ declare module "navy" {
     waitForHealthy: (
       services?: Array<string> | null,
       progressCallback?: (healthData: Array<ServiceHealthData>) => void,
+      retryConfig?: {
+        factor?: number,
+        retries?: number,
+        minTimeout?: number,
+      },
     ) => Promise<boolean>
     ps(): Promise<ServiceList>
   }

--- a/packages/navy/src/navy/index.js
+++ b/packages/navy/src/navy/index.js
@@ -510,7 +510,7 @@ export class Navy extends EventEmitter2 {
           return true
         }
 
-        retry('Timed out waiting for services to be healthy')
+        retry('Timed out waiting for services to be healthy. Unhealthy services: ' + unhealthy.map(s => s.service).join(', '))
       }
     )
   }


### PR DESCRIPTION
I'm getting a timeout in some tests. It would be really useful to be
able to configure the retry behaviour to wait for longer.