### PR TITLE
Allow larger buffers for response headers

### DIFF
--- a/images/nginx-proxy/custom_settings.conf
+++ b/images/nginx-proxy/custom_settings.conf
@@ -1,1 +1,6 @@
 client_max_body_size 10m;
+fastcgi_buffers         16  16k;
+fastcgi_buffer_size         32k;
+proxy_buffer_size          128k;
+proxy_buffers            4 256k;
+proxy_busy_buffers_size    256k;


### PR DESCRIPTION
This will resolve an issue where Auth0 sends large response headers and breaks nginx