### PR TITLE
Increase large client request headers buffer

### DIFF
--- a/images/nginx-proxy/custom_settings.conf
+++ b/images/nginx-proxy/custom_settings.conf
@@ -1,9 +1,7 @@
-# This handles the REQUEST headers (the curl command's headers)
-large_client_header_buffers 4 32k;
-
 client_max_body_size 10m;
 fastcgi_buffers         16  16k;
 fastcgi_buffer_size         32k;
 proxy_buffer_size          128k;
 proxy_buffers            4 256k;
 proxy_busy_buffers_size    256k;
+large_client_header_buffers 4 32k;

--- a/images/nginx-proxy/custom_settings.conf
+++ b/images/nginx-proxy/custom_settings.conf
@@ -1,3 +1,6 @@
+# This handles the REQUEST headers (the curl command's headers)
+large_client_header_buffers 4 32k;
+
 client_max_body_size 10m;
 fastcgi_buffers         16  16k;
 fastcgi_buffer_size         32k;


### PR DESCRIPTION
Found it to be an issue when working with service like oauth0 when using it locally for auth. They can return large headers

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small Nginx config tweak that only affects reverse-proxy header buffering; low risk but could slightly increase memory usage per connection if abused.
> 
> **Overview**
> Increases Nginx’s allowed request header buffering by adding `large_client_header_buffers 4 32k` to `images/nginx-proxy/custom_settings.conf`, preventing 400/494 errors when upstreams (e.g., OAuth flows) send large headers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1516c6eb1c53709ddfdd68dd1a9689bc3ea66178. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->